### PR TITLE
Updated OC Interface HLD regarding rate utilization counters enhancements.

### DIFF
--- a/doc/mgmt/SONiC_OC_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_Interface_HLD.md
@@ -16,7 +16,7 @@
 | Rev |     Date    |       Author       | Change Description                |
 |:---:|:-----------:|:------------------:|-----------------------------------|
 | 0.1 | 09/05/2019  |   Justine Jose, Tejaswi Goel, Arthi Sivanantham  | Initial version  |
-| 0.2 | 07/07/2020  |   Ravi Vasanthm  | Adding support for rate utilization counters and rate interval data  |
+| 0.2 | 07/07/2020  |   Ravi Vasanthm  | Included information about rate utilization counters and rate interval data  |
 
 # About this Manual
 This document provides information about the northbound interface details for handling VLAN, PortChannel, Loopback interfaces and design approach for supporting "clear counters" and show interface counters (using interface_counters RPC) commands.

--- a/doc/mgmt/SONiC_OC_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_Interface_HLD.md
@@ -209,6 +209,7 @@ module: openconfig-interfaces
           |  +--ro last-change?     oc-types:timeticks64
           |  +--ro logical?         boolean
           |  +--ro oc-vlan:tpid?    identityref
+          |  +--ro oc-intf-ext:rate-interval?         uint32
           |  +--ro counters
           |  |  +--ro in-octets?                           oc-yang:counter64
           |  |  +--ro in-pkts?                             oc-yang:counter64
@@ -651,13 +652,14 @@ Mode of IPv6 address assignment: MANUAL
 #### Display interface COUNTERS
 `show interface counters`
 ```
-Units: RX_MBPS/TX_MBPS(MB/s), RX_MbPS|TX_MbPS(Mb/s), RX_PPS|TX_PPS(pkts/s) and RX_UTIL|TX_UTIL(%).
-------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Interface      State     RX_OK     RX_MBPS  RX_MbPS  RX_PPS  RX_UTIL  RX_ERR    RX_DRP    RX_OVR   TX_OK    TX_MBPS  TX_MbPS  TX_PPS  TX_UTIL TX_ERR    TX_DRP   TX_OVR
-------------------------------------------------------------------------------------------------
-Ethernet0      D         0         0.00      0.00     0.00   0.00     0         0         0        0        0.00   0.00     0.00    0.00    0         0         0
-PortChannel1   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00     0.00    0.00    0         0         0
-PortChannel2   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00     0.00    0.00    0         0         0
+                                   ---------------------------------                                        ---------------------------------
+                                   MB/s      Mb/s     Pkts/s  %                                              MB/s    Mb/s     Pkts/s   %
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Ethernet0      D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00      0.00    0.00    0         0         0
+PortChannel1   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00      0.00    0.00    0         0         0
+PortChannel2   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00      0.00    0.00    0         0         0
 ```
 
 #### 3.6.2.2.2 PORTCHANNEL
@@ -781,7 +783,7 @@ N/A
 **GET**
 Get PortChannel details:
 - `/openconfig-interfaces:interfaces/interface={name}`
-- `/openconfig-interfaces:interfaces/interface={name}/state/[mtu|admin-status|oper-status]`
+- `/openconfig-interfaces:interfaces/interface={name}/state/[mtu|admin-status|oper-status|oc-intf-ext:rate-interval]`
 - `/openconfig-interfaces:interfaces/interface={name}/openconfig-if-aggregate:aggregation/state/[min-links|member|lag-type]`
 - `/openconfig-interfaces:interfaces/interface={name}/openconfig-if-aggregate:aggregation/state/[dell-intf-augments:fallback|dell-intf-augments:fast_rate]`
 
@@ -798,6 +800,9 @@ Get PortChannel details:
 
 **GET**
 - `/openconfig-interfaces:interfaces/ interface={name}`
+
+** Get Counters including Rate and utilization info **
+
 - `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-octets-per-second`
 ```
 Example Value

--- a/doc/mgmt/SONiC_OC_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_Interface_HLD.md
@@ -218,8 +218,6 @@ module: openconfig-interfaces
           |  |  +--ro in-multicast-pkts?                   oc-yang:counter64
           |  |  +--ro in-discards?                         oc-yang:counter64
           |  |  +--ro in-errors?                           oc-yang:counter64
-          |  |  +--ro in-unknown-protos?                   oc-yang:counter64
-          |  |  +--ro in-fcs-errors?                       oc-yang:counter64
           |  |  +--ro out-octets?                          oc-yang:counter64
           |  |  +--ro out-pkts?                            oc-yang:counter64
           |  |  +--ro out-unicast-pkts?                    oc-yang:counter64
@@ -227,7 +225,6 @@ module: openconfig-interfaces
           |  |  +--ro out-multicast-pkts?                  oc-yang:counter64
           |  |  +--ro out-discards?                        oc-yang:counter64
           |  |  +--ro out-errors?                          oc-yang:counter64
-          |  |  +--ro carrier-transitions?                 oc-yang:counter64
           |  |  +--ro last-clear?                          oc-types:timeticks64
   +       |  |  +--ro oc-intf-ext:in-octets-per-second?    decimal64
   +       |  |  +--ro oc-intf-ext:in-pkts-per-second?      decimal64

--- a/doc/mgmt/SONiC_OC_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_Interface_HLD.md
@@ -19,10 +19,10 @@
 | 0.2 | 07/07/2020  |   Ravi Vasanthm  | Adding support for rate utilization counters and rate interval data  |
 
 # About this Manual
-This document provides information about the northbound interface details for handling Ethernet, VLAN, PortChannel, Loopback interfaces and design approach for supporting "clear counters" and show interface counters (using interface_counters RPC) commands.
+This document provides information about the northbound interface details for handling VLAN, PortChannel, Loopback interfaces and design approach for supporting "clear counters" and show interface counters (using interface_counters RPC) commands.
 
 # Scope
-This document covers the "configuration" and "show" commands supported for Ethernet, VLAN, PortChannel and Loopback interfaces based on OpenConfig yang and the associated unit-test cases. It does not include the protocol design or protocol implementation details.
+This document covers the "configuration" and "show" commands supported for VLAN, PortChannel and Loopback interfaces based on OpenConfig yang and the associated unit-test cases. It does not include the protocol design or protocol implementation details.
 
 # Definition/Abbreviation
 
@@ -96,9 +96,9 @@ N/A
 
 # 2 Functionality
 ## 2.1 Target Deployment Use Cases
-Manage/configure Ethernet, VLAN, PortChannel and Loopback interface via CLI, gNMI and REST interfaces
+Manage/configure VLAN, PortChannel and Loopback interface via CLI, gNMI and REST interfaces
 ## 2.2 Functional Description
-1. Provide CLI, gNMI and REST support for Ethernet, VLAN, PortChannel and Loopback related commands handling.
+1. Provide CLI, gNMI and REST support for VLAN, PortChannel and Loopback related commands handling.
 2. Provide CLI/REST/gNMI commands to reset interface statistics.
 
 # 3 Design
@@ -650,29 +650,16 @@ Mode of IPv6 address assignment: MANUAL
 ```
 #### Display interface COUNTERS
 `show interface counters`
-Units: RX_MBPS/TX_MBPS(MB/s), RX_MbPS|TX_MbPS(Mb/s), RX_PPS|TX_PPS(pkts/s)
+```
+Units: RX_MBPS/TX_MBPS(MB/s), RX_MbPS|TX_MbPS(Mb/s), RX_PPS|TX_PPS(pkts/s) and RX_UTIL|TX_UTIL(%).
+------------------------------------------------------------------------------------------------
+Interface      State     RX_OK     RX_MBPS  RX_MbPS  RX_PPS  RX_UTIL  RX_ERR    RX_DRP    RX_OVR   TX_OK    TX_MBPS  TX_MbPS  TX_PPS  TX_UTIL TX_ERR    TX_DRP   TX_OVR
+------------------------------------------------------------------------------------------------
+Ethernet0      D         0         0.00      0.00     0.00   0.00     0         0         0        0        0.00   0.00     0.00    0.00    0         0         0
+PortChannel1   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00     0.00    0.00    0         0         0
+PortChannel2   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00     0.00    0.00    0         0         0
+```
 
-Interface    State    RX_OK RX_MBPS  RX_MbPS  RX_PPS  RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK  TX_MBPS    TX_MbPS  TX_PPS  TX_UTIL    TX_ERR    TX_DRP    TX_OVR
-------------  -------  -------  --------  --------  ---------  --------  --------  --------  -------    --------  --------  ---------  --------  --------  --------
-  Ethernet48   U     87,219  0.00   0.00  0.00        0.00%         0         3         0   86,871      0.00   0.00  0.00 0.00%         0         0         0
-  Ethernet49   U    5,649  0.00   0.00  0.00 0.00%         0     5,649         0    5,645      0.00   0.00  0.00 0.00%         0         0         0  
-  ........
-  PortChannel1 U    5,649  0.00   0.00  0.00 0.00%         0     5,649         0    5,645      0.00   0.00  0.00 0.00%         0         0         0
-```
-##### show interface Ethernet <>
-```
-sonic# show interface Ethernet 64
-Ethernet64 is up, line protocol is up
-Hardware is Eth
-Mode of IPV4 address assignment: not-set
-Mode of IPV6 address assignment: not-set
-Interface IPv6 oper status: Disabled
-IP MTU 9100 bytes
-LineSpeed 25GB, Auto-negotiation off
-Last clearing of "show interface" counters: 1970-01-01 00:00:00
-30 seconds input rate 84640 bits/sec, 10236 Bytes/sec, 52 packets/sec
-30 seconds output rate 176760 bits/sec, 22432 Bytes/sec, 45 packets/sec
-```
 #### 3.6.2.2.2 PORTCHANNEL
 #### Display summary information about PortChannels
 - sonic-portchannel.yang and teamd used for CLI #show commands.

--- a/doc/mgmt/SONiC_OC_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_Interface_HLD.md
@@ -229,11 +229,11 @@ module: openconfig-interfaces
   +       |  |  +--ro oc-intf-ext:in-octets-per-second?    decimal64
   +       |  |  +--ro oc-intf-ext:in-pkts-per-second?      decimal64
   +       |  |  +--ro oc-intf-ext:in-bits-per-second?      decimal64
-  +       |  |  +--ro oc-intf-ext:in-utilization?          decimal64
+  +       |  |  +--ro oc-intf-ext:in-utilization?          oc-types:percentage
   +       |  |  +--ro oc-intf-ext:out-octets-per-second?   decimal64
   +       |  |  +--ro oc-intf-ext:out-pkts-per-second?     decimal64
   +       |  |  +--ro oc-intf-ext:out-bits-per-second?     decimal64
-  +       |  |  +--ro oc-intf-ext:out-utilization?         decimal64
+  +       |  |  +--ro oc-intf-ext:out-utilization?         oc-types:percentage
           +--rw hold-time
           |  +--rw config
           |  |  +--rw up?     uint32
@@ -341,6 +341,7 @@ module: sonic-interface
 +       +--ro output
 +          +--ro status?   int32
 +          +--ro status-detail?   string
+```
 ```diff
 module:sonic-counters
 rpcs:
@@ -362,7 +363,7 @@ rpcs:
    |                 +--ro in-octets-per-second?    decimal64
    |                 +--ro in-pkts-per-second?      decimal64
    |                 +--ro in-bits-per-second?      decimal64
-   |                 +--ro in-utilization?          decimal64
+   |                 +--ro in-utilization?          oc-types:percentage
    |                 +--ro out-octets?              uint64
    |                 +--ro out-pkts?                uint64
    |                 +--ro out-discards?            uint64
@@ -371,7 +372,7 @@ rpcs:
    |                 +--ro out-octets-per-second?   decimal64
    |                 +--ro out-pkts-per-second?     decimal64
    |                 +--ro out-bits-per-second?     decimal64
-   |                 +--ro out-utilization?         decimal64
+   |                 +--ro out-utilization?         oc-types:percentage
 
 
 ```

--- a/doc/mgmt/SONiC_OC_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_Interface_HLD.md
@@ -16,10 +16,9 @@
 | Rev |     Date    |       Author       | Change Description                |
 |:---:|:-----------:|:------------------:|-----------------------------------|
 | 0.1 | 09/05/2019  |   Justine Jose, Tejaswi Goel, Arthi Sivanantham  | Initial version  |
-| 0.2 | 07/07/2020  |   Ravi Vasanthm  | Included information about rate utilization counters and rate interval data  |
 
 # About this Manual
-This document provides information about the northbound interface details for handling VLAN, PortChannel, Loopback interfaces and design approach for supporting "clear counters" and show interface counters (using interface_counters RPC) commands.
+This document provides information about the northbound interface details for handling VLAN, PortChannel, Loopback interfaces and design approach for supporting "clear counters" commands.
 
 # Scope
 This document covers the "configuration" and "show" commands supported for VLAN, PortChannel and Loopback interfaces based on OpenConfig yang and the associated unit-test cases. It does not include the protocol design or protocol implementation details.
@@ -41,8 +40,6 @@ Provide management framework capabilities to handle:
 ### ETHERNET
 - MTU, IPv4 / IPv6, sflow, admin-status, description, nat-zone, <br />
   spanning-tree, switchport, channel-group and udld configuration
-- IPv4 / IPv6 address configuration
-- IPv4 / IPv6 address removal
 - Associated show commands
 - Support clearing Ethernet counter values displayed by the "show interface" commands. <br />
   User will be able to clear counters for all interfaces or given interface type or given interface name.
@@ -209,31 +206,6 @@ module: openconfig-interfaces
           |  +--ro last-change?     oc-types:timeticks64
           |  +--ro logical?         boolean
           |  +--ro oc-vlan:tpid?    identityref
-          |  +--ro oc-intf-ext:rate-interval?         uint32
-          |  +--ro counters
-          |  |  +--ro in-octets?                           oc-yang:counter64
-          |  |  +--ro in-pkts?                             oc-yang:counter64
-          |  |  +--ro in-unicast-pkts?                     oc-yang:counter64
-          |  |  +--ro in-broadcast-pkts?                   oc-yang:counter64
-          |  |  +--ro in-multicast-pkts?                   oc-yang:counter64
-          |  |  +--ro in-discards?                         oc-yang:counter64
-          |  |  +--ro in-errors?                           oc-yang:counter64
-          |  |  +--ro out-octets?                          oc-yang:counter64
-          |  |  +--ro out-pkts?                            oc-yang:counter64
-          |  |  +--ro out-unicast-pkts?                    oc-yang:counter64
-          |  |  +--ro out-broadcast-pkts?                  oc-yang:counter64
-          |  |  +--ro out-multicast-pkts?                  oc-yang:counter64
-          |  |  +--ro out-discards?                        oc-yang:counter64
-          |  |  +--ro out-errors?                          oc-yang:counter64
-          |  |  +--ro last-clear?                          oc-types:timeticks64
-  +       |  |  +--ro oc-intf-ext:in-octets-per-second?    decimal64
-  +       |  |  +--ro oc-intf-ext:in-pkts-per-second?      decimal64
-  +       |  |  +--ro oc-intf-ext:in-bits-per-second?      decimal64
-  +       |  |  +--ro oc-intf-ext:in-utilization?          oc-types:percentage
-  +       |  |  +--ro oc-intf-ext:out-octets-per-second?   decimal64
-  +       |  |  +--ro oc-intf-ext:out-pkts-per-second?     decimal64
-  +       |  |  +--ro oc-intf-ext:out-bits-per-second?     decimal64
-  +       |  |  +--ro oc-intf-ext:out-utilization?         oc-types:percentage
           +--rw hold-time
           |  +--rw config
           |  |  +--rw up?     uint32
@@ -341,39 +313,6 @@ module: sonic-interface
 +       +--ro output
 +          +--ro status?   int32
 +          +--ro status-detail?   string
-```
-```diff
-module:sonic-counters
-rpcs:
-   +---x interface_counters
-   |  +--ro output
-   |     +--ro status?          int32
-   |     +--ro status-detail?   string
-   |     +--ro interfaces
-   |        +--ro interface* [name]
-   |           +--ro name     string
-   |           +--ro state
-   |              +--ro oper-status?   string
-   |              +--ro counters
-   |                 +--ro in-octets?               uint64
-   |                 +--ro in-pkts?                 uint64
-   |                 +--ro in-discards?             uint64
-   |                 +--ro in-errors?               uint64
-   |                 +--ro in-oversize-frames?      uint64
-   |                 +--ro in-octets-per-second?    decimal64
-   |                 +--ro in-pkts-per-second?      decimal64
-   |                 +--ro in-bits-per-second?      decimal64
-   |                 +--ro in-utilization?          oc-types:percentage
-   |                 +--ro out-octets?              uint64
-   |                 +--ro out-pkts?                uint64
-   |                 +--ro out-discards?            uint64
-   |                 +--ro out-errors?              uint64
-   |                 +--ro out-oversize-frames?     uint64
-   |                 +--ro out-octets-per-second?   decimal64
-   |                 +--ro out-pkts-per-second?     decimal64
-   |                 +--ro out-bits-per-second?     decimal64
-   |                 +--ro out-utilization?         oc-types:percentage
-
 
 ```
 ### 3.6.2 CLI
@@ -647,19 +586,6 @@ Mode of IPv4 address assignment: MANUAL
 IPv6 address is a::b/64
 Mode of IPv6 address assignment: MANUAL
 ```
-#### Display interface COUNTERS
-`show interface counters`
-```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Interface      State     RX_OK     RX_MBPS  RX_MbPS  RX_PPS  RX_UTIL  RX_ERR    RX_DRP    RX_OVR   TX_OK    TX_MBPS  TX_MbPS  TX_PPS  TX_UTIL TX_ERR    TX_DRP   TX_OVR
-                                   ---------------------------------                                        ---------------------------------
-                                   MB/s      Mb/s     Pkts/s  %                                              MB/s    Mb/s     Pkts/s   %
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Ethernet0      D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00      0.00    0.00    0         0         0
-PortChannel1   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00      0.00    0.00    0         0         0
-PortChannel2   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00      0.00    0.00    0         0         0
-```
-
 #### 3.6.2.2.2 PORTCHANNEL
 #### Display summary information about PortChannels
 - sonic-portchannel.yang and teamd used for CLI #show commands.
@@ -694,8 +620,6 @@ Members in this channel: Ethernet56(Selected)
 LACP Actor port 56  address 90:b1:1c:f4:a8:7e key 1
 LACP Partner port 0  address 00:00:00:00:00:00 key 0
 Last clearing of "show interface" counters: 2019-12-06 21:23:20
-30 seconds input rate 84640 bits/sec, 10236 Bytes/sec, 52 packets/sec
-30 seconds output rate 176760 bits/sec, 22432 Bytes/sec, 45 packets/sec
 Input statistics:
         6224 packets, 1787177 octets
         2855 Multicasts, 3369 Broadcasts, 0 Unicasts
@@ -779,9 +703,9 @@ N/A
 - Remove member: `/openconfig-interfaces:interfaces/interface={name}/openconfig-if-ethernet:ethernet/config/openconfig-if-aggregate:aggregate-id`
 
 **GET**
-Get PortChannel details:
+Get PortChannel details: 
 - `/openconfig-interfaces:interfaces/interface={name}`
-- `/openconfig-interfaces:interfaces/interface={name}/state/[mtu|admin-status|oper-status|oc-intf-ext:rate-interval]`
+- `/openconfig-interfaces:interfaces/interface={name}/state/[mtu|admin-status|oper-status]`
 - `/openconfig-interfaces:interfaces/interface={name}/openconfig-if-aggregate:aggregation/state/[min-links|member|lag-type]`
 - `/openconfig-interfaces:interfaces/interface={name}/openconfig-if-aggregate:aggregation/state/[dell-intf-augments:fallback|dell-intf-augments:fast_rate]`
 
@@ -799,143 +723,9 @@ Get PortChannel details:
 **GET**
 - `/openconfig-interfaces:interfaces/ interface={name}`
 
-** Get Counters including Rate and utilization info **
-
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-octets-per-second`
-```
-Example Value
-{
-  "openconfig-interfaces-ext:in-octets-per-second": 0
-}
-```
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-pkts-per-second`
-```
-Example Value
-{
-  "openconfig-interfaces-ext:in-pkts-per-second": 0
-}
-```
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-bits-per-second`
-```
-Example Value
-{
-  "openconfig-interfaces-ext:in-bits-per-second": 0
-}
-```
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-utilization`
-```
-Example Value
-{
-  "openconfig-interfaces-ext:in-utilization": 0
-}
-```
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:out-octets-per-second`
-```
-Example Value
-{
-  "openconfig-interfaces-ext:out-octets-per-second": 0
-}
-```
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:out-pkts-per-second`
-```
-Example Value
-{
-  "openconfig-interfaces-ext:out-pkts-per-second": 0
-}
-```
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:out-bits-per-second`
-```
-Example Value
-{
-  "openconfig-interfaces-ext:out-bits-per-second": 0
-}
-```
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:out-utilization`
-```
-Example Value
-{
-  "openconfig-interfaces-ext:out-utilization": 0
-}
-```
-- `/openconfig-interfaces:interfaces/interface={name}/state/counters`
-```
-Sample output:
-{
-  "openconfig-interfaces:counters": {
-    "in-octets": 0,
-    "in-pkts": 0,
-    "in-unicast-pkts": 0,
-    "in-broadcast-pkts": 0,
-    "in-multicast-pkts": 0,
-    "in-discards": 0,
-    "in-errors": 0,
-    "in-unknown-protos": 0,
-    "in-fcs-errors": 0,
-    "out-octets": 0,
-    "out-pkts": 0,
-    "out-unicast-pkts": 0,
-    "out-broadcast-pkts": 0,
-    "out-multicast-pkts": 0,
-    "out-discards": 0,
-    "out-errors": 0,
-    "carrier-transitions": 0,
-    "last-clear": 0,
-    "openconfig-interfaces-ext:in-octets-per-second": 0,
-    "openconfig-interfaces-ext:in-pkts-per-second": 0,
-    "openconfig-interfaces-ext:in-bits-per-second": 0,
-    "openconfig-interfaces-ext:in-utilization": 0,
-    "openconfig-interfaces-ext:out-octets-per-second": 0,
-    "openconfig-interfaces-ext:out-pkts-per-second": 0,
-    "openconfig-interfaces-ext:out-bits-per-second": 0,
-    "openconfig-interfaces-ext:out-utilization": 0
-  }
-}
-```
-
 ##### Clear interface statistics
 - rpc_sonic_interface_clear_counters: `sonic-interface:clear_counters`
 
-##### Query interface COUNTERS
-- rpc_sonic_counters_interface_counters: `sonic-counters:interface_counters`
-```
-Sample output:
-{
-  "sonic-counters:output": {
-    "status": 0,
-    "status-detail": "string",
-    "interfaces": {
-      "interface": [
-        {
-          "name": "string",
-          "state": {
-            "oper-status": "string",
-            "counters": {
-              "in-octets": 0,
-              "in-pkts": 0,
-              "in-discards": 0,
-              "in-errors": 0,
-              "in-oversize-frames": 0,
-              "in-octets-per-second": 0,
-              "in-pkts-per-second": 0,
-              "in-bits-per-second": 0,
-              "in-utilization": 0,
-              "out-octets": 0,
-              "out-pkts": 0,
-              "out-discards": 0,
-              "out-errors": 0,
-              "out-oversize-frames": 0,
-              "out-octets-per-second": 0,
-              "out-pkts-per-second": 0,
-              "out-bits-per-second": 0,
-              "out-utilization": 0
-            }
-          }
-        }
-      ]
-    }
-  }
-}
-```
 # 4 Flow Diagrams
 N/A
 

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -380,22 +380,33 @@ eth0                Management0         up             up             1000MB    
   Note - Need to add eth0 interface as part of interfaces counters list.
 ```
 #show interface counters
+------------------------------------------------------------------------------------------------
+Interface      State     RX_OK     RX_ERR    RX_DRP    TX_OK     TX_ERR    TX_DRP
+------------------------------------------------------------------------------------------------
+Ethernet0      D         0         0         0         0         0         0
+Ethernet4      U         1064      0         0         438       0         0
+Ethernet8      D         0         0         0         0         0         0
+Ethernet12     D         0         0         0         0         0         0
+Ethernet16     D         0         0         0         0         0         0
+Ethernet20     D         0         0         0         0         0         0
+Ethernet24     D         0         0         0         0         0         0
+Ethernet28     D         0         0         0         0         0         0
+Ethernet32     U         431       0         0         438       0         0
+Ethernet36     D         0         0         0         0         0         0
+Ethernet40     D         0         0         0         0         0         0
+```
+
+3. show interface counters rate - Displays rate and utilization counters of all Ethernet and portchannel interfaces.
+```
+#show interface counters rate
 Units: MB/s for RX_MBPS/TX_MBPS, Mb/s for RX_MbPS|TX_MbPS, Pkts/s for RX_PPS|TX_PPS and % for RX_UTIL|TX_UTIL.
-------------------------------------------------------------------------------------------------
-Interface      State     RX_OK     RX_MBPS  RX_MbPS  RX_PPS  RX_UTIL  RX_ERR    RX_DRP    RX_OVR   TX_OK    TX_MBPS  TX_MbPS  TX_PPS  TX_UTIL TX_ERR    TX_DRP   TX_OVR
-------------------------------------------------------------------------------------------------
-Ethernet0      D         0         0.00      0.00     0.00   0.00     0         0         0        0        0.00   0.00     0.00    0.00    0         0         0
-Ethernet4      U         1064      0.00      0.00     0.00   0.00     0         0         0        438       0.00   0.00     0.00    0.00    0         0         0
-Ethernet8      D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
-Ethernet12     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
-Ethernet16     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
-Ethernet20     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
-Ethernet24     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
-Ethernet28     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
-Ethernet32     U         431       0.00      0.00     0.00   0.00     0         0         0        438       0.00   0.00     0.00    0.00    0         0         0
-Ethernet36     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
-Ethernet40     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
-PortChannel1   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00     0.00    0.00    0         0         0
+---------------------------------------------------------------------------------------------------------------------------------------
+Interface      State  RX_MBPS(MB/s) RX_MbPS(Mb/s)  RX_PPS(Pkts/s)  RX_UTIL(%)  TX_MBPS(MB/s)  TX_MbPS(Mb/s)  TX_PPS(Pkts/s)  TX_UTIL(%) 
+---------------------------------------------------------------------------------------------------------------------------------------
+Ethernet0      D      0.00          0.00           0.00            0           0.00           0.00           0.00            0
+Ethernet8      D      0.00          0.00           0.00            0           0.00           0.00           0.00            0
+PortChannel1   U      0.00          0.00           0.00            0           0.00           0.00           0.00            0
+PortChannel2   U      0.00          0.00           0.00            0           0.00           0.00           0.00            0
 ```
 #### 3.6.2.3 Debug Commands
 N/A

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -16,7 +16,7 @@ OpenConfig support for Physical and Management interfaces via openconfig-interfa
 | Rev |     Date    |       Author       | Change Description                |
 |:---:|:-----------:|:------------------:|-----------------------------------|
 | 0.1 | 09/09/2019  |   Ravi Vasanthm     | Initial version                   |
-| 0.2 | 07/08/2019  |   Ravi Vasanthm     | Adding support for rate utilization counters and rate interval data                   |
+| 0.2 | 07/08/2019  |   Ravi Vasanthm     | Included information about rate utilization counters and rate interval data                   |
 
 # About this Manual
 This document provides general information about OpenConfig support for Physical and Management interfaces handling in SONiC.

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -348,8 +348,8 @@ Interface IPv6 oper status: Disabled
 IP MTU 9100 bytes
 LineSpeed 25GB, Auto-negotiation off
 Last clearing of "show interface" counters: 1970-01-01 00:00:00
-30 seconds input rate 84640 bits/sec, 10236 Bytes/sec, 52 packets/sec
-30 seconds output rate 176760 bits/sec, 22432 Bytes/sec, 45 packets/sec
+30 seconds input rate 52 packets/sec, 84640 bits/sec, 10236 Bytes/sec
+30 seconds output rate 45 packets/sec, 176760 bits/sec, 22432 Bytes/sec
 Input statistics:
         6224 packets, 1787177 octets
         2855 Multicasts, 3369 Broadcasts, 0 Unicasts

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -136,6 +136,7 @@ module: openconfig-interfaces
           |  +--ro ifindex?         uint32
           |  +--ro admin-status     enumeration
           |  +--ro oper-status      enumeration
+          |  +--ro oc-intf-ext:rate-interval?         uint32
           |  +--ro counters
           |  |  +--ro in-octets?             oc-yang:counter64
           |  |  +--ro in-pkts?               oc-yang:counter64
@@ -379,7 +380,7 @@ eth0                Management0         up             up             1000MB    
   Note - Need to add eth0 interface as part of interfaces counters list.
 ```
 #show interface counters
-Units: RX_MBPS/TX_MBPS(MB/s), RX_MbPS|TX_MbPS(Mb/s), RX_PPS|TX_PPS(pkts/s) and RX_UTIL|TX_UTIL(%).
+Units: MB/s for RX_MBPS/TX_MBPS, Mb/s for RX_MbPS|TX_MbPS, Pkts/s for RX_PPS|TX_PPS and % for RX_UTIL|TX_UTIL.
 ------------------------------------------------------------------------------------------------
 Interface      State     RX_OK     RX_MBPS  RX_MbPS  RX_PPS  RX_UTIL  RX_ERR    RX_DRP    RX_OVR   TX_OK    TX_MBPS  TX_MbPS  TX_PPS  TX_UTIL TX_ERR    TX_DRP   TX_OVR
 ------------------------------------------------------------------------------------------------
@@ -403,6 +404,14 @@ N/A
 
 ### 3.6.3 REST API Support
 **GET**
+- `/openconfig-interfaces:interfaces/interface={name}/state/openconfig-interfaces-ext:rate-interval`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:rate-interval": 30
+}
+```
+
 - `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-octets-per-second`
 ```
 Example Value

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -16,6 +16,7 @@ OpenConfig support for Physical and Management interfaces via openconfig-interfa
 | Rev |     Date    |       Author       | Change Description                |
 |:---:|:-----------:|:------------------:|-----------------------------------|
 | 0.1 | 09/09/2019  |   Ravi Vasanthm     | Initial version                   |
+| 0.2 | 07/08/2019  |   Ravi Vasanthm     | Adding support for rate utilization counters and rate interval data                   |
 
 # About this Manual
 This document provides general information about OpenConfig support for Physical and Management interfaces handling in SONiC.
@@ -150,6 +151,14 @@ module: openconfig-interfaces
           |  |  +--ro out-multicast-pkts?    oc-yang:counter64
           |  |  +--ro out-discards?          oc-yang:counter64
           |  |  +--ro out-errors?            oc-yang:counter64
+          |  |  +--ro oc-intf-ext:in-octets-per-second?    decimal64
+          |  |  +--ro oc-intf-ext:in-pkts-per-second?      decimal64
+          |  |  +--ro oc-intf-ext:in-bits-per-second?      decimal64
+          |  |  +--ro oc-intf-ext:in-utilization?          decimal64
+          |  |  +--ro oc-intf-ext:out-octets-per-second?   decimal64
+          |  |  +--ro oc-intf-ext:out-pkts-per-second?     decimal64
+          |  |  +--ro oc-intf-ext:out-bits-per-second?     decimal64
+          |  |  +--ro oc-intf-ext:out-utilization?         decimal64
           +--rw subinterfaces
           |  +--rw subinterface* [index]
           |     +--rw index           -> ../config/index
@@ -181,6 +190,39 @@ module: openconfig-interfaces
           |  |  +--rw oc-eth:auto-negotiate?        boolean
           |  |  +--ro oc-eth:port-speed?               identityref
 
+```
+### Interface Counters RPC
+```diff
+module:sonic-counters
+rpcs:
+   +---x interface_counters
+   |  +--ro output
+   |     +--ro status?          int32
+   |     +--ro status-detail?   string
+   |     +--ro interfaces
+   |        +--ro interface* [name]
+   |           +--ro name     string
+   |           +--ro state
+   |              +--ro oper-status?   string
+   |              +--ro counters
+   |                 +--ro in-octets?               uint64
+   |                 +--ro in-pkts?                 uint64
+   |                 +--ro in-discards?             uint64
+   |                 +--ro in-errors?               uint64
+   |                 +--ro in-oversize-frames?      uint64
+   |                 +--ro in-octets-per-second?    decimal64
+   |                 +--ro in-pkts-per-second?      decimal64
+   |                 +--ro in-bits-per-second?      decimal64
+   |                 +--ro in-utilization?          decimal64
+   |                 +--ro out-octets?              uint64
+   |                 +--ro out-pkts?                uint64
+   |                 +--ro out-discards?            uint64
+   |                 +--ro out-errors?              uint64
+   |                 +--ro out-oversize-frames?     uint64
+   |                 +--ro out-octets-per-second?   decimal64
+   |                 +--ro out-pkts-per-second?     decimal64
+   |                 +--ro out-bits-per-second?     decimal64
+   |                 +--ro out-utilization?         decimal64
 ```
 ```
 ### 3.6.2 CLI
@@ -294,6 +336,28 @@ Output statistics:
         0 Multicasts, 0 Broadcasts, 0 Unicasts
         0 error, 0 discarded
 ```
+2. show interface Ethernet 64 - display details about interface Ethernet64
+```
+sonic# show interface Ethernet 64
+Ethernet64 is up, line protocol is up
+Hardware is Eth
+Mode of IPV4 address assignment: not-set
+Mode of IPV6 address assignment: not-set
+Interface IPv6 oper status: Disabled
+IP MTU 9100 bytes
+LineSpeed 25GB, Auto-negotiation off
+Last clearing of "show interface" counters: 1970-01-01 00:00:00
+30 seconds input rate 84640 bits/sec, 10236 Bytes/sec, 52 packets/sec
+30 seconds output rate 176760 bits/sec, 22432 Bytes/sec, 45 packets/sec
+Input statistics:
+        6224 packets, 1787177 octets
+        2855 Multicasts, 3369 Broadcasts, 0 Unicasts
+        0 error, 3 discarded
+Output statistics:
+        74169 packets, 10678293 octets
+        70186 Multicasts, 3983 Broadcasts, 0 Unicasts
+        0 error, 0 discarded
+```
 ##### CLI's list which need's to be enhanced to add Management interface details>
 1. show interface status - Displays a brief summary of the interfaces.
   Note: Need to add eth0 interface as part of interfaces status list.
@@ -315,21 +379,22 @@ eth0                Management0         up             up             1000MB    
   Note - Need to add eth0 interface as part of interfaces counters list.
 ```
 #show interface counters
+Units: RX_MBPS/TX_MBPS(MB/s), RX_MbPS|TX_MbPS(Mb/s), RX_PPS|TX_PPS(pkts/s) and RX_UTIL|TX_UTIL(%).
 ------------------------------------------------------------------------------------------------
-Interface      State     RX_OK     RX_ERR    RX_DRP    TX_OK     TX_ERR    TX_DRP
+Interface      State     RX_OK     RX_MBPS  RX_MbPS  RX_PPS  RX_UTIL  RX_ERR    RX_DRP    RX_OVR   TX_OK    TX_MBPS  TX_MbPS  TX_PPS  TX_UTIL TX_ERR    TX_DRP   TX_OVR
 ------------------------------------------------------------------------------------------------
-Ethernet0      D         0         0         0         0         0         0
-Ethernet4      U         1064      0         0         438       0         0
-Ethernet8      D         0         0         0         0         0         0
-Ethernet12     D         0         0         0         0         0         0
-Ethernet16     D         0         0         0         0         0         0
-Ethernet20     D         0         0         0         0         0         0
-Ethernet24     D         0         0         0         0         0         0
-Ethernet28     D         0         0         0         0         0         0
-Ethernet32     U         431       0         0         438       0         0
-Ethernet36     D         0         0         0         0         0         0
-Ethernet40     D         0         0         0         0         0         0
-eth0           U        23233      0         0         33220     0         0
+Ethernet0      D         0         0.00      0.00     0.00   0.00     0         0         0        0        0.00   0.00     0.00    0.00    0         0         0
+Ethernet4      U         1064      0.00      0.00     0.00   0.00     0         0         0        438       0.00   0.00     0.00    0.00    0         0         0
+Ethernet8      D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
+Ethernet12     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
+Ethernet16     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
+Ethernet20     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
+Ethernet24     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
+Ethernet28     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
+Ethernet32     U         431       0.00      0.00     0.00   0.00     0         0         0        438       0.00   0.00     0.00    0.00    0         0         0
+Ethernet36     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
+Ethernet40     D         0         0.00      0.00     0.00   0.00     0         0         0        0         0.00   0.00     0.00    0.00    0         0         0
+PortChannel1   U        23233      0.00      0.00     0.00   0.00     0         0         0        33220     0.00   0.00     0.00    0.00    0         0         0
 ```
 #### 3.6.2.3 Debug Commands
 N/A
@@ -337,7 +402,138 @@ N/A
 N/A
 
 ### 3.6.3 REST API Support
-N/A
+**GET**
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-octets-per-second`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:in-octets-per-second": 0
+}
+```
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-pkts-per-second`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:in-pkts-per-second": 0
+}
+```
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-bits-per-second`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:in-bits-per-second": 0
+}
+```
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:in-utilization`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:in-utilization": 0
+}
+```
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:out-octets-per-second`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:out-octets-per-second": 0
+}
+```
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:out-pkts-per-second`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:out-pkts-per-second": 0
+}
+```
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:out-bits-per-second`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:out-bits-per-second": 0
+}
+```
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters/openconfig-interfaces-ext:out-utilization`
+```
+Example Value
+{
+  "openconfig-interfaces-ext:out-utilization": 0
+}
+```
+- `/openconfig-interfaces:interfaces/interface={name}/state/counters`
+```
+Sample output:
+{
+  "openconfig-interfaces:counters": {
+    "in-octets": 0,
+    "in-pkts": 0,
+    "in-unicast-pkts": 0,
+    "in-broadcast-pkts": 0,
+    "in-multicast-pkts": 0,
+    "in-discards": 0,
+    "in-errors": 0,
+    "in-unknown-protos": 0,
+    "in-fcs-errors": 0,
+    "out-octets": 0,
+    "out-pkts": 0,
+    "out-unicast-pkts": 0,
+    "out-broadcast-pkts": 0,
+    "out-multicast-pkts": 0,
+    "out-discards": 0,
+    "out-errors": 0,
+    "carrier-transitions": 0,
+    "last-clear": 0,
+    "openconfig-interfaces-ext:in-octets-per-second": 0,
+    "openconfig-interfaces-ext:in-pkts-per-second": 0,
+    "openconfig-interfaces-ext:in-bits-per-second": 0,
+    "openconfig-interfaces-ext:in-utilization": 0,
+    "openconfig-interfaces-ext:out-octets-per-second": 0,
+    "openconfig-interfaces-ext:out-pkts-per-second": 0,
+    "openconfig-interfaces-ext:out-bits-per-second": 0,
+    "openconfig-interfaces-ext:out-utilization": 0
+  }
+}
+```
+##### Query interface COUNTERS
+- rpc_sonic_counters_interface_counters: `sonic-counters:interface_counters`
+```
+Sample output:
+{
+  "sonic-counters:output": {
+    "status": 0,
+    "status-detail": "string",
+    "interfaces": {
+      "interface": [
+        {
+          "name": "string",
+          "state": {
+            "oper-status": "string",
+            "counters": {
+              "in-octets": 0,
+              "in-pkts": 0,
+              "in-discards": 0,
+              "in-errors": 0,
+              "in-oversize-frames": 0,
+              "in-octets-per-second": 0,
+              "in-pkts-per-second": 0,
+              "in-bits-per-second": 0,
+              "in-utilization": 0,
+              "out-octets": 0,
+              "out-pkts": 0,
+              "out-discards": 0,
+              "out-errors": 0,
+              "out-oversize-frames": 0,
+              "out-octets-per-second": 0,
+              "out-pkts-per-second": 0,
+              "out-bits-per-second": 0,
+              "out-utilization": 0
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
 # 4 Flow Diagrams
 N/A
 

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -155,11 +155,11 @@ module: openconfig-interfaces
           |  |  +--ro oc-intf-ext:in-octets-per-second?    decimal64
           |  |  +--ro oc-intf-ext:in-pkts-per-second?      decimal64
           |  |  +--ro oc-intf-ext:in-bits-per-second?      decimal64
-          |  |  +--ro oc-intf-ext:in-utilization?          decimal64
+          |  |  +--ro oc-intf-ext:in-utilization?          oc-types:percentage
           |  |  +--ro oc-intf-ext:out-octets-per-second?   decimal64
           |  |  +--ro oc-intf-ext:out-pkts-per-second?     decimal64
           |  |  +--ro oc-intf-ext:out-bits-per-second?     decimal64
-          |  |  +--ro oc-intf-ext:out-utilization?         decimal64
+          |  |  +--ro oc-intf-ext:out-utilization?         oc-types:percentage
           +--rw subinterfaces
           |  +--rw subinterface* [index]
           |     +--rw index           -> ../config/index
@@ -214,7 +214,7 @@ rpcs:
    |                 +--ro in-octets-per-second?    decimal64
    |                 +--ro in-pkts-per-second?      decimal64
    |                 +--ro in-bits-per-second?      decimal64
-   |                 +--ro in-utilization?          decimal64
+   |                 +--ro in-utilization?          oc-types:percentage
    |                 +--ro out-octets?              uint64
    |                 +--ro out-pkts?                uint64
    |                 +--ro out-discards?            uint64
@@ -223,7 +223,7 @@ rpcs:
    |                 +--ro out-octets-per-second?   decimal64
    |                 +--ro out-pkts-per-second?     decimal64
    |                 +--ro out-bits-per-second?     decimal64
-   |                 +--ro out-utilization?         decimal64
+   |                 +--ro out-utilization?         oc-types:percentage
 ```
 ```
 ### 3.6.2 CLI

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -407,10 +407,10 @@ interfaces.
 Interface     Rate interval RX_MBPS   RX_MbPS  RX_PPS    RX_UTIl  TX_MBPS   TX_MbPS  TX_PPS     TX_UTIL(%)
               (seconds)     (MB/s)    (Mb/s)   (Pkts/s)   (%)     (MB/s)    (Mb/s)   (Pkts/s)   (%)
 -----------------------------------------------------------------------------------------------------------
-Ethernet0     0             0.00      0.00     0.00      0        0.00      0.00     0.00       0
-Ethernet8     0             0.00      0.00     0.00      0        0.00      0.00     0.00       0
-PortChannel1  0             0.00      0.00     0.00      0        0.00      0.00     0.00       0
-PortChannel2  0             0.00      0.00     0.00      0        0.00      0.00     0.00       0
+Ethernet0     10            0.00      0.00     0.00      0        0.00      0.00     0.00       0
+Ethernet8     10            0.00      0.00     0.00      0        0.00      0.00     0.00       0
+PortChannel1  10            0.00      0.00     0.00      0        0.00      0.00     0.00       0
+PortChannel2  10            0.00      0.00     0.00      0        0.00      0.00     0.00       0
 ```
 #### 3.6.2.3 Debug Commands
 N/A

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -404,13 +404,13 @@ interfaces.
 #show interface counters rate
 
 -----------------------------------------------------------------------------------------------------------
-Interface     RX_MBPS   RX_MbPS  RX_PPS    RX_UTIl  TX_MBPS   TX_MbPS  TX_PPS     TX_UTIL(%)
-              (MB/s)    (Mb/s)   (Pkts/s)   (%)     (MB/s)    (Mb/s)   (Pkts/s)   (%)
+Interface     Rate interval RX_MBPS   RX_MbPS  RX_PPS    RX_UTIl  TX_MBPS   TX_MbPS  TX_PPS     TX_UTIL(%)
+              (seconds)     (MB/s)    (Mb/s)   (Pkts/s)   (%)     (MB/s)    (Mb/s)   (Pkts/s)   (%)
 -----------------------------------------------------------------------------------------------------------
-Ethernet0     0.00      0.00     0.00      0        0.00      0.00     0.00       0
-Ethernet8     0.00      0.00     0.00      0        0.00      0.00     0.00       0
-PortChannel1  0.00      0.00     0.00      0        0.00      0.00     0.00       0
-PortChannel2  0.00      0.00     0.00      0        0.00      0.00     0.00       0
+Ethernet0     0             0.00      0.00     0.00      0        0.00      0.00     0.00       0
+Ethernet8     0             0.00      0.00     0.00      0        0.00      0.00     0.00       0
+PortChannel1  0             0.00      0.00     0.00      0        0.00      0.00     0.00       0
+PortChannel2  0             0.00      0.00     0.00      0        0.00      0.00     0.00       0
 ```
 #### 3.6.2.3 Debug Commands
 N/A

--- a/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
+++ b/doc/mgmt/SONiC_OC_MGMT_Interface_HLD.md
@@ -193,7 +193,7 @@ module: openconfig-interfaces
 
 ```
 ### Interface Counters RPC
-```diff
+```
 module:sonic-counters
 rpcs:
    +---x interface_counters
@@ -225,10 +225,10 @@ rpcs:
    |                 +--ro out-bits-per-second?     decimal64
    |                 +--ro out-utilization?         oc-types:percentage
 ```
-```
+
 ### 3.6.2 CLI
 #### 3.6.2.1 Configuration Commands
-
+```
   sonic(config)# interface ?
   Ethernet    Interface commands
   Management  Management Interface commands
@@ -359,9 +359,10 @@ Output statistics:
         70186 Multicasts, 3983 Broadcasts, 0 Unicasts
         0 error, 0 discarded
 ```
-##### CLI's list which need's to be enhanced to add Management interface details>
+##### CLI's list which need's to be enhanced to add Management interface details
+
 1. show interface status - Displays a brief summary of the interfaces.
-  Note: Need to add eth0 interface as part of interfaces status list.
+
 ```
 #show interface status
 ------------------------------------------------------------------------------------------
@@ -374,10 +375,10 @@ Ethernet12          Ethernet12          up             down           40GB      
 Ethernet16          -                   up             down           40GB           9100
 Ethernet20          -                   up             down           40GB           9100
 Ethernet24          -                   up             down           40GB           9100
-eth0                Management0         up             up             1000MB         1500
 ```
+
 2. show interface counters - Displays port statistics of all physical interfaces.
-  Note - Need to add eth0 interface as part of interfaces counters list.
+
 ```
 #show interface counters
 ------------------------------------------------------------------------------------------------
@@ -396,17 +397,20 @@ Ethernet36     D         0         0         0         0         0         0
 Ethernet40     D         0         0         0         0         0         0
 ```
 
-3. show interface counters rate - Displays rate and utilization counters of all Ethernet and portchannel interfaces.
+3. show interface counters rate - Displays rate and utilization counters of all Ethernet and port channel
+interfaces.
+
 ```
 #show interface counters rate
-Units: MB/s for RX_MBPS/TX_MBPS, Mb/s for RX_MbPS|TX_MbPS, Pkts/s for RX_PPS|TX_PPS and % for RX_UTIL|TX_UTIL.
----------------------------------------------------------------------------------------------------------------------------------------
-Interface      State  RX_MBPS(MB/s) RX_MbPS(Mb/s)  RX_PPS(Pkts/s)  RX_UTIL(%)  TX_MBPS(MB/s)  TX_MbPS(Mb/s)  TX_PPS(Pkts/s)  TX_UTIL(%) 
----------------------------------------------------------------------------------------------------------------------------------------
-Ethernet0      D      0.00          0.00           0.00            0           0.00           0.00           0.00            0
-Ethernet8      D      0.00          0.00           0.00            0           0.00           0.00           0.00            0
-PortChannel1   U      0.00          0.00           0.00            0           0.00           0.00           0.00            0
-PortChannel2   U      0.00          0.00           0.00            0           0.00           0.00           0.00            0
+
+-----------------------------------------------------------------------------------------------------------
+Interface     RX_MBPS   RX_MbPS  RX_PPS    RX_UTIl  TX_MBPS   TX_MbPS  TX_PPS     TX_UTIL(%)
+              (MB/s)    (Mb/s)   (Pkts/s)   (%)     (MB/s)    (Mb/s)   (Pkts/s)   (%)
+-----------------------------------------------------------------------------------------------------------
+Ethernet0     0.00      0.00     0.00      0        0.00      0.00     0.00       0
+Ethernet8     0.00      0.00     0.00      0        0.00      0.00     0.00       0
+PortChannel1  0.00      0.00     0.00      0        0.00      0.00     0.00       0
+PortChannel2  0.00      0.00     0.00      0        0.00      0.00     0.00       0
 ```
 #### 3.6.2.3 Debug Commands
 N/A


### PR DESCRIPTION
Changes:

1. Updated SONiC_OC_Interface_HLD.md doc with new counters attributes details and Interface_counters RPC enhancement.
2. New show command to display rate and utilization counters for Ethernet and port channel interfaces.
    show interface counters rate
3. show interface Ethernet <> and show interface PortChannel <> enhancements based on new counters and RPC enhancements..